### PR TITLE
fixed bug in msboxes Skourlis 140623

### DIFF
--- a/msboxes/msboxes.ado
+++ b/msboxes/msboxes.ado
@@ -166,7 +166,7 @@ program define msboxes, rclass
         
 // end state (assumes some ordering)
         tempvar maxeventtime totalmiss
-        qui bysort `id' (_trans): egen `maxeventtime' = max(_stop*_status )
+        qui bysort `id' (_trans): egen double `maxeventtime' = max(_stop*_status )
         qui bysort `id' (_trans): gen `endstate' = _to if _stop == `maxeventtime' & _status==1 
         qui bysort `id' (_trans): egen `totalmiss' = total(`endstate'==.)
         qui bysort `id' (_trans): replace `endstate' = _from if `totalmiss' == _N & _n==1


### PR DESCRIPTION
The tempvar maxeventtime in the msboxes.ado had an arbitrary number of decimal places. That was creating an issue when it was compared with the time variables to count how many individuals are in each state by the end of their follow-up in the msboxes graph. I now defined it as a double and the counting is properly done. The bug should now be fixed.